### PR TITLE
feature: Add jmespath input mapping

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,14 @@
 routes:
+  "/v1/orders/:userId":
+    post:
+      exchange: "amq.topic"
+      routingKey: "orders.create"
+      replyRoutingKey: "orders.create.reply"
+      inputMapping:
+        user: "params.path[2]"
+        product: "body.item.sku"
+        quantity: "query.qty"
+        notes: "body.note"
   "/v1/storage":
     get:
       exchange: "amq.topic"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
         "amqplib": "^0.10.7",
+        "jmespath": "^0.16.0",
         "path-to-regexp": "^8.2.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
@@ -7798,6 +7799,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/js-tokens": {
@@ -16521,6 +16530,11 @@
           }
         }
       }
+    },
+    "jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "amqplib": "^0.10.7",
+    "jmespath": "^0.16.0",
     "path-to-regexp": "^8.2.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"


### PR DESCRIPTION
Adds JMESPath support for input mapping from HTTP -> AMQP  Example:

routes:
  "/v1/orders/:userId":
    post:
      exchange: "amq.topic"
      routingKey: "orders.create"
      replyRoutingKey: "orders.create.reply"
      inputMapping:
        user: "params.path[2]"
        product: "body.item.sku"
        quantity: "query.qty"
        notes: "body.note"

POST http://localhost:3000/http://localhost:3000/v1/orders/dbrame?product=product1&quantity=5
Request Body
{
    "item": {
        "sku":"skunumber1"
    },
    "note": "abracadabra"
}

becomes:

{"user":"dbrame","product":"skunumber1","quantity":"5","notes":"abracadabra"}